### PR TITLE
Update result2test.py

### DIFF
--- a/result2test.py
+++ b/result2test.py
@@ -1,7 +1,7 @@
 import cv2
 import numpy as np
 import matplotlib.pyplot as plt 
-from skimage.measure import compare_ssim, compare_psnr
+from skimage.metrics import structural_similarity
 
 SRC_PATH = "./results_k9"
 DST_PATH = "./rainy_image_dataset/testing_results_k9"


### PR DESCRIPTION
It arises an error (ImportError: cannot import name 'compare_ssim' from 'skimage.measure') while running "result2test.py". The error is because of the fact skimage.measure.compare_ssim has been removed in skimage 0.18. 

To fix the issue, a line in the code in respective file needs to be changed from "from skimage.measure import compare_ssim, compare_psnr" to "from skimage.metrics import structural_similarity".