### PR TITLE
Update validation.py

### DIFF
--- a/validation.py
+++ b/validation.py
@@ -3,7 +3,7 @@ import os
 import torch
 import numpy as np
 import cv2
-from skimage.measure import compare_ssim, compare_psnr
+from skimage.metrics import structural_similarity
 
 import utils
 import dataset


### PR DESCRIPTION
It arises an error (ImportError: cannot import name 'compare_ssim' from 'skimage.measure') while running "validation.py". The error is because of the fact skimage.measure.compare_ssim has been removed in skimage 0.18.

To fix the issue, a line in the code in respective file needs to be changed from "from skimage.measure import compare_ssim, compare_psnr" to "from skimage.metrics import structural_similarity".